### PR TITLE
Added pico-w blink example

### DIFF
--- a/pico-w-blink-sdk/BridgingHeader.h
+++ b/pico-w-blink-sdk/BridgingHeader.h
@@ -1,0 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "pico/stdlib.h"
+#include "pico/cyw43_arch.h"

--- a/pico-w-blink-sdk/CMakeLists.txt
+++ b/pico-w-blink-sdk/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.13)
+include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
+
+project(swift-blinky)
+pico_sdk_init()
+execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+add_executable(swift-blinky)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+    COMMAND
+        ${SWIFTC}
+        -target armv6m-none-none-eabi -Xcc -mfloat-abi=soft -Xcc -fshort-enums
+        -Xcc -DCYW43_LWIP
+        -Xcc -DPICO_CYW43_ARCH_THREADSAFE_BACKGROUND
+        -Xcc -I$ENV{PICO_SDK_PATH}/lib/lwip/src/include
+        -Xcc -I${CMAKE_CURRENT_LIST_DIR}/include
+        -Xfrontend -function-sections -enable-experimental-feature Embedded -wmo -parse-as-library
+        $$\( echo '$<TARGET_PROPERTY:swift-blinky,INCLUDE_DIRECTORIES>' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
+        $$\( echo '${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}'             | tr ' '  '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
+        -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
+        ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+        -c -o ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+    DEPENDS
+        ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
+        ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+)
+add_custom_target(swift-blinky-swiftcode DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o)
+
+target_link_libraries(swift-blinky
+    pico_stdlib hardware_uart hardware_gpio pico_lwip_arch pico_cyw43_arch_none
+    ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
+)
+add_dependencies(swift-blinky swift-blinky-swiftcode)
+pico_add_extra_outputs(swift-blinky)

--- a/pico-w-blink-sdk/Main.swift
+++ b/pico-w-blink-sdk/Main.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors.
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+@main
+struct Main {
+    static func main() {
+        let led = UInt32(CYW43_WL_GPIO_LED_PIN)
+        if cyw43_arch_init() != 0 {
+            print("Wi-Fi init failed")
+            return
+        }
+        let dot = {
+            cyw43_arch_gpio_put(led, true)
+            sleep_ms(250)
+            cyw43_arch_gpio_put(led, false)
+            sleep_ms(250)
+        }
+        let dash = {
+            cyw43_arch_gpio_put(led, true)
+            sleep_ms(500)
+            cyw43_arch_gpio_put(led, false)
+            sleep_ms(250)
+        }
+        while true {
+            dot()
+            dot()
+            dot()
+
+            dash()
+            dash()
+            dash()
+
+            dot()
+            dot()
+            dot()
+        }
+    }
+}

--- a/pico-w-blink-sdk/README.md
+++ b/pico-w-blink-sdk/README.md
@@ -1,0 +1,41 @@
+# pico-blink-sdk
+
+This example demonstrates how to integrate with the Pico SDK which is using CMake as its build system -- the simplest way to integrate with it is to also use CMake to build a Swift firmware application on top of the SDK and the libraries from it.
+
+<img src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/pico-blink-sdl.jpg">
+
+## Requirements
+
+- Follow the setup steps at https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf, in particular you'll need:
+  - A checkout of the [pico-sdk](https://github.com/raspberrypi/pico-sdk.git), with git submodules checked out.
+  - A checkout of the [pico-examples](https://github.com/raspberrypi/pico-examples.git).
+  - CMake.
+  - The [Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
+- Before trying to use Swift with the Pico SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
+  - Try building and running the "blink" example from pico-examples written in C.
+
+
+## Building
+
+- Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
+- Build and copy the program in the UF2 format to the Mass Storage device to trigger flashing the program into memory (after which the device will reboot and run the firmware):
+``` console
+$ cd pico-blink-sdk
+$ export TOOLCHAINS='<toolchain-name>'
+$ export PICO_BOARD=pico_w
+$ export PICO_SDK_PATH='<path-to-your-pico-sdk>'
+$ export PICO_TOOLCHAIN_PATH='<path-to-the-arm-toolchain>'
+$ cmake -B build -G Ninja .
+$ cmake --build build
+```
+
+## Running
+
+- Connect the Pico W board via a USB cable to your Mac, and make sure it's in the USB Mass Storage firmware upload mode (either hold the BOOTSEL button while plugging the board, or make sure your Flash memory doesn't contain any valid firmware).
+- Copy the UF2 firmware to the Mass Storage device:
+
+```console
+$ cp build/swift-blinky.uf2 /Volumes/RP2040
+```
+
+- The green LED should now be blinking in a pattern.

--- a/pico-w-blink-sdk/include/lwipopts.h
+++ b/pico-w-blink-sdk/include/lwipopts.h
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Generally you would define your own explicit list of lwIP options
+// (see https://www.nongnu.org/lwip/2_1_x/group__lwip__opts.html)
+
+#ifndef _LWIPOPTS_H
+#define _LWIPOPTS_H
+#endif


### PR DESCRIPTION
Hi! I tried using the [pico-blink-sdk](https://github.com/apple/swift-embedded-examples/tree/main/pico-blink-sdk) with a Pico-W, but it didn't work because the LED module is on the wireless chip. For the Pico-W, the pico-sdk doesn't define PICO_DEFAULT_LED_PIN; instead, it uses CYW43_WL_GPIO_LED_PIN.
Ref: [Pico-SDK](https://github.com/raspberrypi/pico-sdk/blob/6a7db34ff63345a7badec79ebea3aaef1712f374/src/boards/include/boards/pico_w.h#L31C15-L32C37)

I also tried using CYW43_WL_GPIO_LED_PIN to make the Pico-W blink. By linking several necessary modules, I was able to get it working successfully!

I thought this example might be useful to other developers, so I added it!