### PR TITLE
Add README section for community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Note that the SDK integration examples (Pico SDK, Zephyr SDK, etc.) are not reco
 | [PlaydateKit](https://github.com/finnvoor/PlaydateKit) | Playdate | A full featured framework for building Playdate games using Embedded Swift. |
 | [swift-playdate-examples](https://github.com/apple/swift-playdate-examples) | Playdate | A technical demonstration of Embedded Swift running on Playdate by Panic. |
 
-Please note that the presence of community repositories and devices in this list does not constitute a recommendation or endorsement. If there's a project you'd like to see included here, please [submit a PR](https://github.com/apple/swift-playdate-examples/compare) with the details.
+Please note that the presence of community repositories and devices in this list does not constitute a recommendation or endorsement. If there's a project you'd like to see included here, please [submit an issue](https://github.com/apple/swift-embedded-examples/issues/new) with the details.
 
 ## Contributing to this repository
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Embedded Swift Example Projects
 
 This repository is a set of demonstration projects of **Embedded Swift**. Embedded Swift is a compilation and language mode that enables development of baremetal, embedded and standalone software in Swift. To learn more, see:
+
 - [Blog post introducing this repository](https://www.swift.org/blog/embedded-swift-examples/)
 - [Swift forums thread about this repository](https://forums.swift.org/t/embedded-swift-example-projects-for-arm-and-risc-v-microcontrollers/71066)
 - [Discussions about Embedded Swift on the Swift forums](https://forums.swift.org/t/embedded-swift/67057)
@@ -17,16 +18,28 @@ This repository is a set of demonstration projects of **Embedded Swift**. Embedd
 
 | Name      | Board | Description | Photo |
 | --------- | ----- | ----------- | ----- |
-| [stm32-blink](./stm32-blink) |STM32F746G-DISCO|Baremetal program that blinks an LED repeatedly. Does not use any vendor SDKs or external toolchains.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-blink.jpg">|
-| [stm32-lcd-logo](./stm32-lcd-logo) |STM32F746G-DISCO|Sets up layers on the built-in LCD and animates them in a loop. Does not use any vendor SDKs or external toolchains.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-lcd-logo.jpg">|
-| [stm32-neopixel](./stm32-neopixel) |STM32F746G-DISCO|Uses SPI to program a NeoPixel LED strip. Does not use any vendor SDKs or external toolchains.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-led.jpg">|
-| [stm32-uart-echo](./stm32-uart-echo) |STM32F746G-DISCO|Uses UART to implement a simple "echo" firmware. Does not use any vendor SDKs or external toolchains.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-uart-echo.png">| 
-| [pico-blink](./pico-blink) |Raspberry Pi Pico W|Baremetal program that blinks an LED repeatedly. Does not use any vendor SDKs or external toolchains.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/pico-blink.jpg">|
-| [pico-blink-sdk](./pico-blink-sdk) |Raspberry Pi Pico W|Baremetal program that blinks an LED repeatedly. Demonstrates how to use code and libraries from the Pico SDK and add Swift code on top of it.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/pico-blink-sdl.jpg">|
-| [nrfx-blink-sdk](./nrfx-blink-sdk) |nRF52840-DK|Baremetal program that blinks an LED repeatedly. Demonstrates how to use code and libraries from the Zephyr SDK and add Swift code on top of it.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/nrfx-blink-sdk.jpeg">|
-| [esp32-led-strip-sdk](./esp32-led-strip-sdk) |ESP32-C6-DevKitC-1|Demonstrates how to integrate with ESP-IDF SDK and use Swift to control the LED strip library from the SDK.|<img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/esp32-led-strip-sdk.jpg">|
+| [stm32-blink](./stm32-blink) | STM32F746G-DISCO | Baremetal program that blinks an LED repeatedly. Does not use any vendor SDKs or external toolchains. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-blink.jpg"> |
+| [stm32-lcd-logo](./stm32-lcd-logo) | STM32F746G-DISCO | Sets up layers on the built-in LCD and animates them in a loop. Does not use any vendor SDKs or external toolchains. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-lcd-logo.jpg"> |
+| [stm32-neopixel](./stm32-neopixel) | STM32F746G-DISCO | Uses SPI to program a NeoPixel LED strip. Does not use any vendor SDKs or external toolchains. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-led.jpg"> |
+| [stm32-uart-echo](./stm32-uart-echo) | STM32F746G-DISCO | Uses UART to implement a simple "echo" firmware. Does not use any vendor SDKs or external toolchains. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/stm32-uart-echo.png">| 
+| [pico-blink](./pico-blink) | Raspberry Pi Pico W | Baremetal program that blinks an LED repeatedly. Does not use any vendor SDKs or external toolchains. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/pico-blink.jpg"> |
+| [pico-blink-sdk](./pico-blink-sdk) | Raspberry Pi Pico W | Baremetal program that blinks an LED repeatedly. Demonstrates how to use code and libraries from the Pico SDK and add Swift code on top of it. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/pico-blink-sdl.jpg"> |
+| [nrfx-blink-sdk](./nrfx-blink-sdk) | nRF52840-DK | Baremetal program that blinks an LED repeatedly. Demonstrates how to use code and libraries from the Zephyr SDK and add Swift code on top of it. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/nrfx-blink-sdk.jpeg"> |
+| [esp32-led-strip-sdk](./esp32-led-strip-sdk) | ESP32-C6-DevKitC-1 | Demonstrates how to integrate with ESP-IDF SDK and use Swift to control the LED strip library from the SDK. | <img width="300" src="https://raw.githubusercontent.com/kubamracek/swift-evolution/branch/assets/esp32-led-strip-sdk.jpg"> |
 
 Note that the SDK integration examples (Pico SDK, Zephyr SDK, etc.) are not recommendations or endorsement, the same is true for build system choice (Make, CMake, SwiftPM, shell scripts). Embedded Swift aims to be versatile and to allow for integration into more existing SDKs and build systems, and the example projects are merely showing the possibilities.
+
+## Community Examples
+
+<!-- Please keep this list sorted by "Board" then "Name" -->
+
+| Name | Board    | Description |
+| ---- | -------- | ----------- |
+| [swift-flipperzero-hello](https://github.com/Sameesunkaria/swift-flipperzero-hello) | Flipper Zero | A demonstration of running Swift apps on the Flipper Zero. |
+| [PlaydateKit](https://github.com/finnvoor/PlaydateKit) | Playdate | A full featured framework for building Playdate games using Embedded Swift. |
+| [swift-playdate-examples](https://github.com/apple/swift-playdate-examples) | Playdate | A technical demonstration of Embedded Swift running on Playdate by Panic. |
+
+Please note that the presence of community repositories and devices in this list does not constitute a recommendation or endorsement. If there's a project you'd like to see included here, please [submit a PR](https://github.com/apple/swift-playdate-examples/compare) with the details.
 
 ## Contributing to this repository
 


### PR DESCRIPTION
Adds a section to the README for links to community uses of Embedded Swift. This list should be kept sorted by "Board" and then "Name".