### PR TITLE
Fix calling convention on putchar (silgen_name -> cdecl)

### DIFF
--- a/stm32-neopixel/Sources/Application/Application.swift
+++ b/stm32-neopixel/Sources/Application/Application.swift
@@ -134,7 +134,7 @@ public func defaultHandler() {
   while true { }
 }
 
-@_silgen_name("putchar")
+@_cdecl("putchar")
 public func putchar(_ value: CInt) -> CInt {
   while usart1.isr.read().raw.txe == 0 { }
   usart1.tdr.modify { $0.raw.tdr_field = UInt32(value) }

--- a/stm32-uart-echo/Sources/Application/Application.swift
+++ b/stm32-uart-echo/Sources/Application/Application.swift
@@ -106,7 +106,7 @@ public func defaultHandler() {
   while true { }
 }
 
-@_silgen_name("putchar")
+@_cdecl("putchar")
 public func putchar(_ value: CInt) -> CInt {
   waitTxBufferEmpty()
   tx(value: UInt8(value))


### PR DESCRIPTION
This should make the example projects build agains the current nightly toolchains. The compiler change that starting causing the mismatch is this one: https://github.com/apple/swift/pull/72973

