### PR TITLE
esp: add march and mabi flags for all riscv chips

### DIFF
--- a/esp32-led-blink-sdk/main/CMakeLists.txt
+++ b/esp32-led-blink-sdk/main/CMakeLists.txt
@@ -3,6 +3,24 @@ idf_component_register(
     INCLUDE_DIRS "."
 )
 
+idf_build_get_property(target IDF_TARGET)
+idf_build_get_property(arch IDF_TARGET_ARCH)
+
+if("${arch}" STREQUAL "xtensa")
+    message(FATAL_ERROR "Not supported target: ${target}")
+endif()
+
+if(${target} STREQUAL "esp32c2" OR ${target} STREQUAL "esp32c3")
+    set(march_flag "rv32imc_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+elseif(${target} STREQUAL "esp32p4")
+    set(march_flag "rv32imafc_zicsr_zifencei")
+    set(mabi_flag "ilp32f")
+else()
+    set(march_flag "rv32imac_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+endif()
+
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_custom_command(
@@ -11,6 +29,7 @@ add_custom_command(
         ${SWIFTC}
         -target riscv32-none-none-eabi
         -Xfrontend -function-sections -enable-experimental-feature Embedded -wmo -parse-as-library -Osize
+        -Xcc -march=${march_flag} -Xcc -mabi=${mabi_flag}
         $$\( echo '$<TARGET_PROPERTY:__idf_main,INCLUDE_DIRECTORIES>' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
         $$\( echo '${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}'           | tr ' '  '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
         -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h

--- a/esp32-led-strip-sdk/main/CMakeLists.txt
+++ b/esp32-led-strip-sdk/main/CMakeLists.txt
@@ -3,6 +3,24 @@ idf_component_register(
     INCLUDE_DIRS "."
 )
 
+idf_build_get_property(target IDF_TARGET)
+idf_build_get_property(arch IDF_TARGET_ARCH)
+
+if("${arch}" STREQUAL "xtensa")
+    message(FATAL_ERROR "Not supported target: ${target}")
+endif()
+
+if(${target} STREQUAL "esp32c2" OR ${target} STREQUAL "esp32c3")
+    set(march_flag "rv32imc_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+elseif(${target} STREQUAL "esp32p4")
+    set(march_flag "rv32imafc_zicsr_zifencei")
+    set(mabi_flag "ilp32f")
+else()
+    set(march_flag "rv32imac_zicsr_zifencei")
+    set(mabi_flag "ilp32")
+endif()
+
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_custom_command(
@@ -11,6 +29,7 @@ add_custom_command(
         ${SWIFTC}
         -target riscv32-none-none-eabi
         -Xfrontend -function-sections -enable-experimental-feature Embedded -wmo -parse-as-library -Osize
+        -Xcc -march=${march_flag} -Xcc -mabi=${mabi_flag}
         $$\( echo '$<TARGET_PROPERTY:__idf_main,INCLUDE_DIRECTORIES>' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
         $$\( echo '${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES}'           | tr ' '  '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
         -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h


### PR DESCRIPTION
A better solution could be to get the March and Mabi flags from the idf `toolchain-clang-<target>.cmake` file. However, for now, the IDF build uses the GCC toolchain instead of Clang. I would like to test the Clang build and then modify the related parts.

Closes #19 