### PR TITLE
esp: add linker fragment file

### DIFF
--- a/esp32-led-blink-sdk/main/CMakeLists.txt
+++ b/esp32-led-blink-sdk/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
     SRCS "Dummy.c"
     INCLUDE_DIRS "."
+    LDFRAGMENTS "linker.lf"
 )
 
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/esp32-led-blink-sdk/main/linker.lf
+++ b/esp32-led-blink-sdk/main/linker.lf
@@ -1,0 +1,20 @@
+[sections:flash_text_swift]
+entries:
+    .swift_modhash+
+
+[sections:dram0_swift]
+entries:
+    .got+
+    .got.plt+
+
+[scheme:swift_default]
+entries:
+    flash_text_swift -> flash_text
+    dram0_swift -> dram0_data
+
+[mapping:swift_default]
+archive: *
+entries:
+    * (swift_default);
+    flash_text_swift -> flash_text SURROUND (swift_text),
+    dram0_swift -> dram0_data SURROUND (swift_dram0)

--- a/esp32-led-strip-sdk/main/CMakeLists.txt
+++ b/esp32-led-strip-sdk/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 idf_component_register(
     SRCS "Dummy.c"
     INCLUDE_DIRS "."
+    LDFRAGMENTS "linker.lf"
 )
 
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/esp32-led-strip-sdk/main/linker.lf
+++ b/esp32-led-strip-sdk/main/linker.lf
@@ -1,0 +1,20 @@
+[sections:flash_text_swift]
+entries:
+    .swift_modhash+
+
+[sections:dram0_swift]
+entries:
+    .got+
+    .got.plt+
+
+[scheme:swift_default]
+entries:
+    flash_text_swift -> flash_text
+    dram0_swift -> dram0_data
+
+[mapping:swift_default]
+archive: *
+entries:
+    * (swift_default);
+    flash_text_swift -> flash_text SURROUND (swift_text),
+    dram0_swift -> dram0_data SURROUND (swift_dram0)


### PR DESCRIPTION
With the help of linker fragment files, it is possible to specify custom placements at the component level within ESP-IDF.

https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/linker-script-generation.html