### PR TITLE
update gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 */.build
 */build
 */sdkconfig
+*/sdkconfig.old
 */managed_components
+*/dependencies.lock

--- a/esp32-led-blink-sdk/dependencies.lock
+++ b/esp32-led-blink-sdk/dependencies.lock
@@ -1,9 +1,0 @@
-dependencies:
-  idf:
-    component_hash: null
-    source:
-      type: idf
-    version: 5.2.1
-manifest_hash: 4bd9cabb9e4ea4c9742d3fdac782a5f66e6b6b748ce0bf390a9183818d1a2291
-target: esp32c6
-version: 1.0.0


### PR DESCRIPTION
When cmake configures the project, "dependencies.lock" file will be generated automatically. So no need to keep it in the repo.

More context related to component manager https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/tools/idf-component-manager.html