### PR TITLE
Multiplatform `cmake` builds

### DIFF
--- a/esp32-led-blink-sdk/main/CMakeLists.txt
+++ b/esp32-led-blink-sdk/main/CMakeLists.txt
@@ -22,7 +22,11 @@ else()
     set(mabi_flag "ilp32")
 endif()
 
+if(APPLE)
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o

--- a/esp32-led-strip-sdk/main/CMakeLists.txt
+++ b/esp32-led-strip-sdk/main/CMakeLists.txt
@@ -22,7 +22,11 @@ else()
     set(mabi_flag "ilp32")
 endif()
 
+if(APPLE)
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o

--- a/nrfx-blink-sdk/CMakeLists.txt
+++ b/nrfx-blink-sdk/CMakeLists.txt
@@ -4,7 +4,12 @@ project(blinky)
 
 target_sources(app PRIVATE Stubs.c)
 
+if(APPLE)
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
+
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
     COMMAND

--- a/pico-blink-sdk/CMakeLists.txt
+++ b/pico-blink-sdk/CMakeLists.txt
@@ -3,7 +3,12 @@ include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 project(swift-blinky)
 pico_sdk_init()
+
+if(APPLE)
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 add_executable(swift-blinky)
 add_custom_command(

--- a/pico-w-blink-sdk/CMakeLists.txt
+++ b/pico-w-blink-sdk/CMakeLists.txt
@@ -3,7 +3,12 @@ include($ENV{PICO_SDK_PATH}/external/pico_sdk_import.cmake)
 
 project(swift-blinky)
 pico_sdk_init()
+
+if(APPLE)
 execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+else()
+execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 
 add_executable(swift-blinky)
 add_custom_command(


### PR DESCRIPTION
Improve the "out-of-the-box" experience on platforms without `xcrun` by locating `swiftc` with `which` instead.  Conceptually, something similar should be possible for the builds that use shell scripts, but I don't have a strong opinion about how to do that stylistically.

Updated examples which use `cmake`:

- [x] `esp32-led-strip-sdk`
- [x] `esp32-led-blink-sdk`
- [x] `pico-blink-sdk`
- [x] `pico-w-blink-sdk`
- [x] `nrfx-blink-sdk`

Tested updates:

- [x] `esp32-led-strip-sdk`
  - [x] Linux (`swiftly` installed `main-snapshot`)
  - [x] macOS (package-installed `main-snapshot`)
- [x] `esp32-led-blink-sdk`
  - [x] Linux (`swiftly` installed `main-snapshot`)
  - [x] macOS (package-installed `main-snapshot`)
- [ ] `pico-blink-sdk`
  - [x] Linux (`swiftly` installed `main-snapshot`)
  - [ ] macOS (package-installed `main-snapshot`)
- [ ] `pico-w-blink-sdk`
  - [x] Linux (`swiftly` installed `main-snapshot`)
  - [ ] macOS (package-installed `main-snapshot`)
- [ ] `nrfx-blink-sdk`
  - [ ] Linux (`swiftly` installed `main-snapshot`) (IN PROGRESS)
  - [ ] macOS (package-installed `main-snapshot`)

Given the similarity of how CMake is used across these examples, I think having the `esp32` examples continuing to work on macOS and the other examples newly working on Linux would constitute sufficient testing.