### PR TITLE
Use new swift-mmio naming @RegisterBlock, fix build of STM32 example

### DIFF
--- a/stm32-uart-echo/Package.resolved
+++ b/stm32-uart-echo/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "ea83017c944c7850b8f60207e6143eb17cb6b5e6b734b3fa08787a5d920dba7b",
+  "originHash" : "a341db4bc8f11a7dc810c323c7d37f2f9a1322e9633ccbec6a8d88de8c055685",
   "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
     {
       "identity" : "swift-mmio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-mmio",
       "state" : {
         "branch" : "swift-embedded-examples",
-        "revision" : "80c109b87511041338a4d8d88064088c8dfc079b"
+        "revision" : "c662f34e89259244f18936cacd356ef2f5e4e4db"
       }
     },
     {

--- a/stm32-uart-echo/Sources/Application/Registers/GPIOA.swift
+++ b/stm32-uart-echo/Sources/Application/Registers/GPIOA.swift
@@ -3,50 +3,50 @@
 import MMIO
 
 /// General-purpose I/Os
-@RegisterBank
+@RegisterBlock
 struct GPIOA {
   /// GPIO port mode register
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var moder: Register<MODER>
 
   /// GPIO port output type register
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var otyper: Register<OTYPER>
 
   /// GPIO port output speed register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var ospeedr: Register<OSPEEDR>
 
   /// GPIO port pull-up/pull-down register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var pupdr: Register<PUPDR>
 
   /// GPIO port input data register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var idr: Register<IDR>
 
   /// GPIO port output data register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var odr: Register<ODR>
 
   /// GPIO port bit set/reset register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var bsrr: Register<BSRR>
 
   /// GPIO port configuration lock register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var lckr: Register<LCKR>
 
   /// GPIO alternate function low register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var afrl: Register<AFRL>
 
   /// GPIO alternate function high register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var afrh: Register<AFRH>
 
   /// GPIO port bit reset register
-  @RegisterBank(offset: 0x28)
+  @RegisterBlock(offset: 0x28)
   var brr: Register<BRR>
 }
 

--- a/stm32-uart-echo/Sources/Application/Registers/RCC.swift
+++ b/stm32-uart-echo/Sources/Application/Registers/RCC.swift
@@ -3,110 +3,110 @@
 import MMIO
 
 /// Reset and clock control
-@RegisterBank
+@RegisterBlock
 struct RCC {
   /// clock control register
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr: Register<CR>
 
   /// PLL configuration register
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var pllcfgr: Register<PLLCFGR>
 
   /// clock configuration register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var cfgr: Register<CFGR>
 
   /// clock interrupt register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var cir: Register<CIR>
 
   /// AHB1 peripheral reset register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var ahb1rstr: Register<AHB1RSTR>
 
   /// AHB2 peripheral reset register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var ahb2rstr: Register<AHB2RSTR>
 
   /// AHB3 peripheral reset register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var ahb3rstr: Register<AHB3RSTR>
 
   /// APB1 peripheral reset register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var apb1rstr: Register<APB1RSTR>
 
   /// APB2 peripheral reset register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var apb2rstr: Register<APB2RSTR>
 
   /// AHB1 peripheral clock register
-  @RegisterBank(offset: 0x30)
+  @RegisterBlock(offset: 0x30)
   var ahb1enr: Register<AHB1ENR>
 
   /// AHB2 peripheral clock enable register
-  @RegisterBank(offset: 0x34)
+  @RegisterBlock(offset: 0x34)
   var ahb2enr: Register<AHB2ENR>
 
   /// AHB3 peripheral clock enable register
-  @RegisterBank(offset: 0x38)
+  @RegisterBlock(offset: 0x38)
   var ahb3enr: Register<AHB3ENR>
 
   /// APB1 peripheral clock enable register
-  @RegisterBank(offset: 0x40)
+  @RegisterBlock(offset: 0x40)
   var apb1enr: Register<APB1ENR>
 
   /// APB2 peripheral clock enable register
-  @RegisterBank(offset: 0x44)
+  @RegisterBlock(offset: 0x44)
   var apb2enr: Register<APB2ENR>
 
   /// AHB1 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x50)
+  @RegisterBlock(offset: 0x50)
   var ahb1lpenr: Register<AHB1LPENR>
 
   /// AHB2 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x54)
+  @RegisterBlock(offset: 0x54)
   var ahb2lpenr: Register<AHB2LPENR>
 
   /// AHB3 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x58)
+  @RegisterBlock(offset: 0x58)
   var ahb3lpenr: Register<AHB3LPENR>
 
   /// APB1 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x60)
+  @RegisterBlock(offset: 0x60)
   var apb1lpenr: Register<APB1LPENR>
 
   /// APB2 peripheral clock enabled in low power mode register
-  @RegisterBank(offset: 0x64)
+  @RegisterBlock(offset: 0x64)
   var apb2lpenr: Register<APB2LPENR>
 
   /// Backup domain control register
-  @RegisterBank(offset: 0x70)
+  @RegisterBlock(offset: 0x70)
   var bdcr: Register<BDCR>
 
   /// clock control & status register
-  @RegisterBank(offset: 0x74)
+  @RegisterBlock(offset: 0x74)
   var csr: Register<CSR>
 
   /// spread spectrum clock generation register
-  @RegisterBank(offset: 0x80)
+  @RegisterBlock(offset: 0x80)
   var sscgr: Register<SSCGR>
 
   /// PLLI2S configuration register
-  @RegisterBank(offset: 0x84)
+  @RegisterBlock(offset: 0x84)
   var plli2scfgr: Register<PLLI2SCFGR>
 
   /// PLL configuration register
-  @RegisterBank(offset: 0x88)
+  @RegisterBlock(offset: 0x88)
   var pllsaicfgr: Register<PLLSAICFGR>
 
   /// dedicated clocks configuration register
-  @RegisterBank(offset: 0x8c)
+  @RegisterBlock(offset: 0x8c)
   var dkcfgr1: Register<DKCFGR1>
 
   /// dedicated clocks configuration register
-  @RegisterBank(offset: 0x90)
+  @RegisterBlock(offset: 0x90)
   var dkcfgr2: Register<DKCFGR2>
 }
 

--- a/stm32-uart-echo/Sources/Application/Registers/USART1.swift
+++ b/stm32-uart-echo/Sources/Application/Registers/USART1.swift
@@ -3,50 +3,50 @@
 import MMIO
 
 /// Universal synchronous asynchronous receiver transmitter
-@RegisterBank
+@RegisterBlock
 struct USART1 {
   /// Control register 1
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr1: Register<CR1>
 
   /// Control register 2
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var cr2: Register<CR2>
 
   /// Control register 3
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var cr3: Register<CR3>
 
   /// Baud rate register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var brr: Register<BRR>
 
   /// Guard time and prescaler register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var gtpr: Register<GTPR>
 
   /// Receiver timeout register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var rtor: Register<RTOR>
 
   /// Request register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var rqr: Register<RQR>
 
   /// Interrupt & status register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var isr: Register<ISR>
 
   /// Interrupt flag clear register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var icr: Register<ICR>
 
   /// Receive data register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var rdr: Register<RDR>
 
   /// Transmit data register
-  @RegisterBank(offset: 0x28)
+  @RegisterBlock(offset: 0x28)
   var tdr: Register<TDR>
 }
 


### PR DESCRIPTION
`@RegisterBank` has been changed to `@RegisterBlock` in swift-mmio, let's reflect that.