### PR TITLE
[stm32-neopixel] Use new @RegisterBlock name, remove warning about swiftpm

### DIFF
--- a/stm32-neopixel/Package.resolved
+++ b/stm32-neopixel/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "ea83017c944c7850b8f60207e6143eb17cb6b5e6b734b3fa08787a5d920dba7b",
+  "originHash" : "c23a233e350eb87b64e1d6f65aeedeb84fdc86c7edd481dd3dae915017d8ac6f",
   "pins" : [
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser.git",
+      "state" : {
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
+      }
+    },
     {
       "identity" : "swift-mmio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-mmio",
       "state" : {
         "branch" : "swift-embedded-examples",
-        "revision" : "80c109b87511041338a4d8d88064088c8dfc079b"
+        "revision" : "c662f34e89259244f18936cacd356ef2f5e4e4db"
       }
     },
     {

--- a/stm32-neopixel/README.md
+++ b/stm32-neopixel/README.md
@@ -18,8 +18,6 @@ We recommend including a capacitor across the LED strip power supply.
 
 ## How to build and run this example:
 
-**⚠️ This example relies on a SwiftPM feature that is not yet present in the nightly downloadable toolchain, https://github.com/apple/swift-package-manager/pull/7353. Currently, it will only build if you have a locally built toolchain with the mentioned PR merged in.**
-
 - Connect the STM32F746G-DISCO board via the ST-LINK USB port to your Mac.
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - Install the `stlink` (https://github.com/stlink-org/stlink) command line tools, e.g. via `brew install stlink`.

--- a/stm32-neopixel/Sources/Application/Registers/DMA1.swift
+++ b/stm32-neopixel/Sources/Application/Registers/DMA1.swift
@@ -3,214 +3,214 @@
 import MMIO
 
 /// DMA controller
-@RegisterBank
+@RegisterBlock
 struct DMA1 {
   /// low interrupt status register
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var lisr: Register<LISR>
 
   /// high interrupt status register
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var hisr: Register<HISR>
 
   /// low interrupt flag clear register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var lifcr: Register<LIFCR>
 
   /// high interrupt flag clear register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var hifcr: Register<HIFCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var s0cr: Register<S0CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var s0ndtr: Register<S0NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var s0par: Register<S0PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var s0m0ar: Register<S0M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var s0m1ar: Register<S0M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var s0fcr: Register<S0FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x28)
+  @RegisterBlock(offset: 0x28)
   var s1cr: Register<S1CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x2c)
+  @RegisterBlock(offset: 0x2c)
   var s1ndtr: Register<S1NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x30)
+  @RegisterBlock(offset: 0x30)
   var s1par: Register<S1PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x34)
+  @RegisterBlock(offset: 0x34)
   var s1m0ar: Register<S1M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x38)
+  @RegisterBlock(offset: 0x38)
   var s1m1ar: Register<S1M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x3c)
+  @RegisterBlock(offset: 0x3c)
   var s1fcr: Register<S1FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x40)
+  @RegisterBlock(offset: 0x40)
   var s2cr: Register<S2CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x44)
+  @RegisterBlock(offset: 0x44)
   var s2ndtr: Register<S2NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x48)
+  @RegisterBlock(offset: 0x48)
   var s2par: Register<S2PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x4c)
+  @RegisterBlock(offset: 0x4c)
   var s2m0ar: Register<S2M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x50)
+  @RegisterBlock(offset: 0x50)
   var s2m1ar: Register<S2M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x54)
+  @RegisterBlock(offset: 0x54)
   var s2fcr: Register<S2FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x58)
+  @RegisterBlock(offset: 0x58)
   var s3cr: Register<S3CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x5c)
+  @RegisterBlock(offset: 0x5c)
   var s3ndtr: Register<S3NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x60)
+  @RegisterBlock(offset: 0x60)
   var s3par: Register<S3PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x64)
+  @RegisterBlock(offset: 0x64)
   var s3m0ar: Register<S3M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x68)
+  @RegisterBlock(offset: 0x68)
   var s3m1ar: Register<S3M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x6c)
+  @RegisterBlock(offset: 0x6c)
   var s3fcr: Register<S3FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x70)
+  @RegisterBlock(offset: 0x70)
   var s4cr: Register<S4CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x74)
+  @RegisterBlock(offset: 0x74)
   var s4ndtr: Register<S4NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x78)
+  @RegisterBlock(offset: 0x78)
   var s4par: Register<S4PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x7c)
+  @RegisterBlock(offset: 0x7c)
   var s4m0ar: Register<S4M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x80)
+  @RegisterBlock(offset: 0x80)
   var s4m1ar: Register<S4M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x84)
+  @RegisterBlock(offset: 0x84)
   var s4fcr: Register<S4FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0x88)
+  @RegisterBlock(offset: 0x88)
   var s5cr: Register<S5CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0x8c)
+  @RegisterBlock(offset: 0x8c)
   var s5ndtr: Register<S5NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0x90)
+  @RegisterBlock(offset: 0x90)
   var s5par: Register<S5PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0x94)
+  @RegisterBlock(offset: 0x94)
   var s5m0ar: Register<S5M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0x98)
+  @RegisterBlock(offset: 0x98)
   var s5m1ar: Register<S5M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0x9c)
+  @RegisterBlock(offset: 0x9c)
   var s5fcr: Register<S5FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0xa0)
+  @RegisterBlock(offset: 0xa0)
   var s6cr: Register<S6CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0xa4)
+  @RegisterBlock(offset: 0xa4)
   var s6ndtr: Register<S6NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0xa8)
+  @RegisterBlock(offset: 0xa8)
   var s6par: Register<S6PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0xac)
+  @RegisterBlock(offset: 0xac)
   var s6m0ar: Register<S6M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0xb0)
+  @RegisterBlock(offset: 0xb0)
   var s6m1ar: Register<S6M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0xb4)
+  @RegisterBlock(offset: 0xb4)
   var s6fcr: Register<S6FCR>
 
   /// stream x configuration register
-  @RegisterBank(offset: 0xb8)
+  @RegisterBlock(offset: 0xb8)
   var s7cr: Register<S7CR>
 
   /// stream x number of data register
-  @RegisterBank(offset: 0xbc)
+  @RegisterBlock(offset: 0xbc)
   var s7ndtr: Register<S7NDTR>
 
   /// stream x peripheral address register
-  @RegisterBank(offset: 0xc0)
+  @RegisterBlock(offset: 0xc0)
   var s7par: Register<S7PAR>
 
   /// stream x memory 0 address register
-  @RegisterBank(offset: 0xc4)
+  @RegisterBlock(offset: 0xc4)
   var s7m0ar: Register<S7M0AR>
 
   /// stream x memory 1 address register
-  @RegisterBank(offset: 0xc8)
+  @RegisterBlock(offset: 0xc8)
   var s7m1ar: Register<S7M1AR>
 
   /// stream x FIFO control register
-  @RegisterBank(offset: 0xcc)
+  @RegisterBlock(offset: 0xcc)
   var s7fcr: Register<S7FCR>
 }
 

--- a/stm32-neopixel/Sources/Application/Registers/GPIOA.swift
+++ b/stm32-neopixel/Sources/Application/Registers/GPIOA.swift
@@ -3,50 +3,50 @@
 import MMIO
 
 /// General-purpose I/Os
-@RegisterBank
+@RegisterBlock
 struct GPIOA {
   /// GPIO port mode register
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var moder: Register<MODER>
 
   /// GPIO port output type register
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var otyper: Register<OTYPER>
 
   /// GPIO port output speed register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var ospeedr: Register<OSPEEDR>
 
   /// GPIO port pull-up/pull-down register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var pupdr: Register<PUPDR>
 
   /// GPIO port input data register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var idr: Register<IDR>
 
   /// GPIO port output data register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var odr: Register<ODR>
 
   /// GPIO port bit set/reset register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var bsrr: Register<BSRR>
 
   /// GPIO port configuration lock register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var lckr: Register<LCKR>
 
   /// GPIO alternate function low register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var afrl: Register<AFRL>
 
   /// GPIO alternate function high register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var afrh: Register<AFRH>
 
   /// GPIO port bit reset register
-  @RegisterBank(offset: 0x28)
+  @RegisterBlock(offset: 0x28)
   var brr: Register<BRR>
 }
 

--- a/stm32-neopixel/Sources/Application/Registers/RCC.swift
+++ b/stm32-neopixel/Sources/Application/Registers/RCC.swift
@@ -3,110 +3,110 @@
 import MMIO
 
 /// Reset and clock control
-@RegisterBank
+@RegisterBlock
 struct RCC {
   /// clock control register
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr: Register<CR>
 
   /// PLL configuration register
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var pllcfgr: Register<PLLCFGR>
 
   /// clock configuration register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var cfgr: Register<CFGR>
 
   /// clock interrupt register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var cir: Register<CIR>
 
   /// AHB1 peripheral reset register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var ahb1rstr: Register<AHB1RSTR>
 
   /// AHB2 peripheral reset register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var ahb2rstr: Register<AHB2RSTR>
 
   /// AHB3 peripheral reset register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var ahb3rstr: Register<AHB3RSTR>
 
   /// APB1 peripheral reset register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var apb1rstr: Register<APB1RSTR>
 
   /// APB2 peripheral reset register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var apb2rstr: Register<APB2RSTR>
 
   /// AHB1 peripheral clock register
-  @RegisterBank(offset: 0x30)
+  @RegisterBlock(offset: 0x30)
   var ahb1enr: Register<AHB1ENR>
 
   /// AHB2 peripheral clock enable register
-  @RegisterBank(offset: 0x34)
+  @RegisterBlock(offset: 0x34)
   var ahb2enr: Register<AHB2ENR>
 
   /// AHB3 peripheral clock enable register
-  @RegisterBank(offset: 0x38)
+  @RegisterBlock(offset: 0x38)
   var ahb3enr: Register<AHB3ENR>
 
   /// APB1 peripheral clock enable register
-  @RegisterBank(offset: 0x40)
+  @RegisterBlock(offset: 0x40)
   var apb1enr: Register<APB1ENR>
 
   /// APB2 peripheral clock enable register
-  @RegisterBank(offset: 0x44)
+  @RegisterBlock(offset: 0x44)
   var apb2enr: Register<APB2ENR>
 
   /// AHB1 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x50)
+  @RegisterBlock(offset: 0x50)
   var ahb1lpenr: Register<AHB1LPENR>
 
   /// AHB2 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x54)
+  @RegisterBlock(offset: 0x54)
   var ahb2lpenr: Register<AHB2LPENR>
 
   /// AHB3 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x58)
+  @RegisterBlock(offset: 0x58)
   var ahb3lpenr: Register<AHB3LPENR>
 
   /// APB1 peripheral clock enable in low power mode register
-  @RegisterBank(offset: 0x60)
+  @RegisterBlock(offset: 0x60)
   var apb1lpenr: Register<APB1LPENR>
 
   /// APB2 peripheral clock enabled in low power mode register
-  @RegisterBank(offset: 0x64)
+  @RegisterBlock(offset: 0x64)
   var apb2lpenr: Register<APB2LPENR>
 
   /// Backup domain control register
-  @RegisterBank(offset: 0x70)
+  @RegisterBlock(offset: 0x70)
   var bdcr: Register<BDCR>
 
   /// clock control & status register
-  @RegisterBank(offset: 0x74)
+  @RegisterBlock(offset: 0x74)
   var csr: Register<CSR>
 
   /// spread spectrum clock generation register
-  @RegisterBank(offset: 0x80)
+  @RegisterBlock(offset: 0x80)
   var sscgr: Register<SSCGR>
 
   /// PLLI2S configuration register
-  @RegisterBank(offset: 0x84)
+  @RegisterBlock(offset: 0x84)
   var plli2scfgr: Register<PLLI2SCFGR>
 
   /// PLL configuration register
-  @RegisterBank(offset: 0x88)
+  @RegisterBlock(offset: 0x88)
   var pllsaicfgr: Register<PLLSAICFGR>
 
   /// dedicated clocks configuration register
-  @RegisterBank(offset: 0x8c)
+  @RegisterBlock(offset: 0x8c)
   var dkcfgr1: Register<DKCFGR1>
 
   /// dedicated clocks configuration register
-  @RegisterBank(offset: 0x90)
+  @RegisterBlock(offset: 0x90)
   var dkcfgr2: Register<DKCFGR2>
 }
 

--- a/stm32-neopixel/Sources/Application/Registers/SPI2.swift
+++ b/stm32-neopixel/Sources/Application/Registers/SPI2.swift
@@ -3,42 +3,42 @@
 import MMIO
 
 /// Serial peripheral interface
-@RegisterBank
+@RegisterBlock
 struct SPI2 {
   /// control register 1
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr1: Register<CR1>
 
   /// control register 2
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var cr2: Register<CR2>
 
   /// status register
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var sr: Register<SR>
 
   /// data register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var dr: Register<DR>
 
   /// CRC polynomial register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var crcpr: Register<CRCPR>
 
   /// RX CRC register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var rxcrcr: Register<RXCRCR>
 
   /// TX CRC register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var txcrcr: Register<TXCRCR>
 
   /// I2S configuration register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var i2scfgr: Register<I2SCFGR>
 
   /// I2S prescaler register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var i2spr: Register<I2SPR>
 }
 

--- a/stm32-neopixel/Sources/Application/Registers/USART1.swift
+++ b/stm32-neopixel/Sources/Application/Registers/USART1.swift
@@ -3,50 +3,50 @@
 import MMIO
 
 /// Universal synchronous asynchronous receiver transmitter
-@RegisterBank
+@RegisterBlock
 struct USART1 {
   /// Control register 1
-  @RegisterBank(offset: 0x0)
+  @RegisterBlock(offset: 0x0)
   var cr1: Register<CR1>
 
   /// Control register 2
-  @RegisterBank(offset: 0x4)
+  @RegisterBlock(offset: 0x4)
   var cr2: Register<CR2>
 
   /// Control register 3
-  @RegisterBank(offset: 0x8)
+  @RegisterBlock(offset: 0x8)
   var cr3: Register<CR3>
 
   /// Baud rate register
-  @RegisterBank(offset: 0xc)
+  @RegisterBlock(offset: 0xc)
   var brr: Register<BRR>
 
   /// Guard time and prescaler register
-  @RegisterBank(offset: 0x10)
+  @RegisterBlock(offset: 0x10)
   var gtpr: Register<GTPR>
 
   /// Receiver timeout register
-  @RegisterBank(offset: 0x14)
+  @RegisterBlock(offset: 0x14)
   var rtor: Register<RTOR>
 
   /// Request register
-  @RegisterBank(offset: 0x18)
+  @RegisterBlock(offset: 0x18)
   var rqr: Register<RQR>
 
   /// Interrupt & status register
-  @RegisterBank(offset: 0x1c)
+  @RegisterBlock(offset: 0x1c)
   var isr: Register<ISR>
 
   /// Interrupt flag clear register
-  @RegisterBank(offset: 0x20)
+  @RegisterBlock(offset: 0x20)
   var icr: Register<ICR>
 
   /// Receive data register
-  @RegisterBank(offset: 0x24)
+  @RegisterBlock(offset: 0x24)
   var rdr: Register<RDR>
 
   /// Transmit data register
-  @RegisterBank(offset: 0x28)
+  @RegisterBlock(offset: 0x28)
   var tdr: Register<TDR>
 }
 


### PR DESCRIPTION
Same as https://github.com/apple/swift-embedded-examples/pull/29, but for `stm32-neopixel`.