### PR TITLE
Update nrfx-blink-sdk example to use native CMake Swift support

### DIFF
--- a/nrfx-blink-sdk/CMakeLists.txt
+++ b/nrfx-blink-sdk/CMakeLists.txt
@@ -1,32 +1,52 @@
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.29)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(blinky)
+
+# Use the armv7em-none-none-eabi target triple for Swift
+set(CMAKE_Swift_COMPILER_TARGET armv7em-none-none-eabi)
+# Enable "wmo" as needed by Embedded Swift
+set(CMAKE_Swift_COMPILATION_MODE wholemodule)
+# FIXME: Skip checking if the compiler works
+set(CMAKE_Swift_COMPILER_WORKS true)
+
+# Create a new project called "blinky" and enable "Swift" as a supported language
+project(blinky Swift)
+
+# Set global Swift compiler flags
+add_compile_options(
+    # Enable Embedded Swift
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-experimental-feature Embedded>"
+
+    # Enable function sections to enable dead code stripping on elf
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -function-sections>"
+
+    # Use software floating point operations matching GCC
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -mfloat-abi=soft>"
+
+    # Use compacted C enums matching GCC
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fshort-enums>"
+
+    # Assortment of defines for Zephyr
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DKERNEL -Xcc -DNRF52840_XXAA -Xcc -DPICOLIBC_INTEGER_PRINTF_SCANF -Xcc -D_FORTIFY_SOURCE=1 -Xcc -D_POSIX_C_SOURCE=200809 -Xcc -D__LINUX_ERRNO_EXTENSIONS__ -Xcc -D__PROGRAM_START -Xcc -D__ZEPHYR__=1>"
+
+    # Add Libc include paths
+    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I -Xcc ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/picolibc/include>"
+)
 
 target_sources(app PRIVATE Stubs.c)
 
-if(APPLE)
-execute_process(COMMAND xcrun -f swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
-else()
-execute_process(COMMAND which swiftc OUTPUT_VARIABLE SWIFTC OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
+add_library(app_swift STATIC Main.swift)
+add_dependencies(app_swift syscall_list_h_target)
+target_compile_options(app_swift PRIVATE
+    -parse-as-library
 
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
-    COMMAND
-        ${SWIFTC}
-        -target armv7em-none-none-eabi -Xcc -mfloat-abi=soft -Xcc -fshort-enums
-        -Xfrontend -function-sections -enable-experimental-feature Embedded -wmo -parse-as-library
-        $$\( echo '$<TARGET_PROPERTY:app,INCLUDE_DIRECTORIES>' | sed 's/;$$//' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc -I\\1/g' \)
-        $$\( echo '$<TARGET_PROPERTY:app,COMPILE_DEFINITIONS>' | sed 's/;$$/' | tr '\;' '\\n' | sed -e 's/\\\(.*\\\)/-Xcc \\1/g' \)
-        -Xcc -DKERNEL -Xcc -DNRF52840_XXAA -Xcc -DPICOLIBC_INTEGER_PRINTF_SCANF -Xcc -D_FORTIFY_SOURCE=1 -Xcc -D_POSIX_C_SOURCE=200809 -Xcc -D__LINUX_ERRNO_EXTENSIONS__ -Xcc -D__PROGRAM_START -Xcc -D__ZEPHYR__=1
-        -Xcc -I/opt/nordic/ncs/toolchains/20d68df7e5/opt/zephyr-sdk/arm-zephyr-eabi/picolibc/include
-        -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
-        ${CMAKE_CURRENT_LIST_DIR}/main.swift
-        -c -o ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o
-    DEPENDS
-        ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
-        ${CMAKE_CURRENT_LIST_DIR}/Main.swift
+    # FIXME: add dependency on BridgingHeader.h
+    -import-bridging-header ${CMAKE_CURRENT_LIST_DIR}/BridgingHeader.h
 )
-add_custom_target(swift-blinky-swiftcode DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o)
-target_link_libraries(app PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/_swiftcode.o)
-add_dependencies(app swift-blinky-swiftcode)
+
+# Copy include paths from C target to Swift target
+target_include_directories(app_swift PRIVATE
+    "$<TARGET_PROPERTY:app,INCLUDE_DIRECTORIES>"
+)
+
+# Link the Swift target into the primary target
+target_link_libraries(app PRIVATE app_swift)

--- a/nrfx-blink-sdk/CMakeLists.txt
+++ b/nrfx-blink-sdk/CMakeLists.txt
@@ -34,7 +34,10 @@ add_compile_options(
 
 target_sources(app PRIVATE Stubs.c)
 
-add_library(app_swift STATIC Main.swift)
+# The Swift code providing "main" needs to be in an OBJECT library (instead of STATIC library) to make sure it actually gets linker.
+# A STATIC library would get dropped from linking because Zephyr provides a default weak empty main definition.
+add_library(app_swift OBJECT Main.swift)
+
 add_dependencies(app_swift syscall_list_h_target)
 target_compile_options(app_swift PRIVATE
     -parse-as-library


### PR DESCRIPTION
This should also resolve https://github.com/apple/swift-embedded-examples/issues/14