### PR TITLE
stm32-uart-echo: Add a .sourcekit-lsp/config.json file to pass triple (and other flags) to SourceKit compilations

### DIFF
--- a/stm32-uart-echo/.sourcekit-lsp/config.json
+++ b/stm32-uart-echo/.sourcekit-lsp/config.json
@@ -1,0 +1,8 @@
+{
+  "swiftPM": {
+    "configuration": "release",
+    "triple": "armv7em-apple-none-macho",
+    "swiftCompilerFlags": ["-Xfrontend", "-disable-stack-protector"],
+    "cCompilerFlags": ["-D__APPLE__", "-D__MACH__"]
+  }
+}


### PR DESCRIPTION
This should fix the problem around LSP not working described in https://forums.swift.org/t/sourcekit-lsp-loading-the-standard-library-failed/73818.

Fixes https://github.com/apple/swift-embedded-examples/issues/46