### PR TITLE
esp32-blink: rename LED to Led

### DIFF
--- a/esp32-led-blink-sdk/main/CMakeLists.txt
+++ b/esp32-led-blink-sdk/main/CMakeLists.txt
@@ -63,5 +63,5 @@ enable_language(Swift)
 target_sources(${COMPONENT_LIB}
     PRIVATE
     Main.swift
-    LED.swift
+    Led.swift
 )


### PR DESCRIPTION
Fix:

```bash
-- Configuring done (2.1s)
CMake Error at main/CMakeLists.txt:63 (target_sources):
  Cannot find source file:

    LED.swift

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc


-- Generating done (0.4s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
FAILED: build.ninja 
```

### Tested on ArchLinux (x86_64/zen3) - GPIO i18 (blink-led)
![image](https://github.com/user-attachments/assets/c16019a2-c702-437c-a1e3-6711331070db)
