### PR TITLE
Add --pico-family parameter

### DIFF
--- a/pico-blink/build.sh
+++ b/pico-blink/build.sh
@@ -2,6 +2,9 @@
 
 set -vex
 
+# Either rp2040 or rp2350
+PICO_FAMILY=rp2040
+
 # Determine file paths
 REPOROOT=$(git rev-parse --show-toplevel)
 TOOLSROOT=$REPOROOT/Tools
@@ -35,7 +38,7 @@ BUILDROOT=$($SWIFT_EXEC build $SWIFT_BUILD_FLAGS --show-bin-path)
 $CLANG .build/release/Support.build/{Support.c,crt0.S}.o .build/release/Blinky.build/*.o -target armv6m-apple-none-macho -o $BUILDROOT/blinky $LD_FLAGS
 
 # Extract sections from executable into flashable binary
-$PYTHON_EXEC $MACHO2UF2 $BUILDROOT/blinky $BUILDROOT/blinky.uf2 --base-address 0x20000000 --segments '__TEXT,__DATA,__VECTORS,__RESET'
+$PYTHON_EXEC $MACHO2UF2 --pico-family $PICO_FAMILY $BUILDROOT/blinky $BUILDROOT/blinky.uf2 --base-address 0x20000000 --segments '__TEXT,__DATA,__VECTORS,__RESET'
 
 # Echo final binary path
 ls -al $BUILDROOT/blinky.uf2


### PR DESCRIPTION
Compilation of the `pico-blink` example failed with the following error:

```
usage: macho2uf2.py [-h] --base-address BASE_ADDRESS --segments SEGMENTS --pico-family PICO_FAMILY input output
macho2uf2.py: error: the following arguments are required: --pico-family
```

Looks like the `--pico-family` parameter became mandatory.

This PR adds a `PICO_FAMILY` variable near the top of the build script, with a comment pointing out the two possible values (according to the source code of `macho2uf2.py`).
It then then sets `--pico-family` to this variable.

Maybe it makes sense to set up some kind of CI to catch these kind of build errors automatically.