### PR TITLE
Fix unknown commits in swift-mmio

### DIFF
--- a/pico2-neopixel/Package.resolved
+++ b/pico2-neopixel/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/apple/swift-mmio.git",
       "state" : {
         "branch" : "swift-embedded-examples",
-        "revision" : "275a877cbdd9d301a783425dbbccc630db364d37"
+        "revision" : "06d96ed4916739f2edafde87f3951b2d2a04df65"
       }
     },
     {

--- a/stm32-neopixel/Package.resolved
+++ b/stm32-neopixel/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/apple/swift-mmio",
       "state" : {
         "branch" : "swift-embedded-examples",
-        "revision" : "c662f34e89259244f18936cacd356ef2f5e4e4db"
+        "revision" : "06d96ed4916739f2edafde87f3951b2d2a04df65"
       }
     },
     {

--- a/stm32-uart-echo/Package.resolved
+++ b/stm32-uart-echo/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/apple/swift-mmio",
       "state" : {
         "branch" : "swift-embedded-examples",
-        "revision" : "c662f34e89259244f18936cacd356ef2f5e4e4db"
+        "revision" : "06d96ed4916739f2edafde87f3951b2d2a04df65"
       }
     },
     {


### PR DESCRIPTION
The pico2-neopixel, stm32-neopixel and stm32-uart-echo examples appear to reference an unknown commits in swift-mmio.

Now they're using the latest commit from the `swift-embedded-examples` branch (06d96).

Error message was:

```
Creating working copy for https://github.com/apple/swift-mmio.git error: 'swift-mmio': Couldn’t check out revision ‘275a877cbdd9d301a783425dbbccc630db364d37’:
    fatal: unable to read tree (275a877cbdd9d301a783425dbbccc630db364d37)
make: *** [build] Error 1
Error: Process completed with exit code 2.
```