### PR TITLE
doc: add simulation of ESP32-C6 with Wokwi

### DIFF
--- a/esp32-led-blink-sdk/README.md
+++ b/esp32-led-blink-sdk/README.md
@@ -37,3 +37,12 @@ $ idf.py flash
 ```
 
 - The LED should be blinking now.
+
+### Simulating in VS Code
+
+- Build the project, to generate binaries for simulation
+- Install [Wokwi for VS Code](https://docs.wokwi.com/vscode/getting-started/).
+- Open the `diagram.json` file.
+- Click the Play button to start simulation.
+- Click the Pause button to freeze simulation and display states of GPIOs.
+

--- a/esp32-led-blink-sdk/diagram.json
+++ b/esp32-led-blink-sdk/diagram.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "author": "Juraj Michálek",
+  "author": "",
   "editor": "wokwi",
   "parts": [
     {

--- a/esp32-led-blink-sdk/diagram.json
+++ b/esp32-led-blink-sdk/diagram.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "author": "Juraj Michálek",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-c6-devkitc-1",
+      "id": "esp",
+      "top": 0,
+      "left": 0,
+      "attrs": { "builder": "esp-idf" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "r1",
+      "top": 119.15,
+      "left": -76.8,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-led",
+      "id": "led1",
+      "top": 25.2,
+      "left": -111.4,
+      "attrs": { "color": "red" }
+    }
+  ],
+  "connections": [
+    [ "esp:TX", "$serialMonitor:RX", "", [] ],
+    [ "esp:RX", "$serialMonitor:TX", "", [] ],
+    [ "r1:2", "esp:8", "red", [ "v0" ] ],
+    [ "r1:1", "led1:A", "red", [ "h0" ] ],
+    [ "led1:C", "esp:GND.1", "black", [ "v0" ] ]
+  ],
+  "dependencies": {}
+}

--- a/esp32-led-blink-sdk/wokwi.toml
+++ b/esp32-led-blink-sdk/wokwi.toml
@@ -1,0 +1,8 @@
+# Wokwi Configuration File
+# Reference: https://docs.wokwi.com/vscode/project-config
+[wokwi]
+version = 1
+firmware = 'build/flasher_args.json'
+elf = 'build/main.elf'
+# gdbServerPort=3333
+

--- a/esp32-led-strip-sdk/README.md
+++ b/esp32-led-strip-sdk/README.md
@@ -36,3 +36,12 @@ $ idf.py flash
 ```
 
 - The LED strip should now be animating a sequence of random colors moving in one direction.
+
+### Simulating in VS Code
+
+- Build the project, to generate binaries for simulation
+- Install [Wokwi for VS Code](https://docs.wokwi.com/vscode/getting-started/).
+- Open the `diagram.json` file.
+- Click the Play button to start simulation.
+- Click the Pause button to freeze simulation and display states of GPIOs.
+

--- a/esp32-led-strip-sdk/diagram.json
+++ b/esp32-led-strip-sdk/diagram.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "author": "Juraj Michálek",
+  "author": "",
   "editor": "wokwi",
   "parts": [
     {

--- a/esp32-led-strip-sdk/diagram.json
+++ b/esp32-led-strip-sdk/diagram.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "author": "Juraj Michálek",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-esp32-c6-devkitc-1",
+      "id": "esp",
+      "top": -13.91,
+      "left": 90.52,
+      "attrs": { "builder": "esp-idf" }
+    },
+    { "type": "wokwi-neopixel", "id": "rgb1", "top": 73.3, "left": -20.2, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb2", "top": 73.3, "left": 18.2, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb3", "top": 73.3, "left": -250.6, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb4", "top": 73.3, "left": -212.2, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb5", "top": 73.3, "left": -58.6, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb6", "top": 73.3, "left": -173.8, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb7", "top": 73.3, "left": -97, "attrs": {} },
+    { "type": "wokwi-neopixel", "id": "rgb8", "top": 73.3, "left": -135.4, "attrs": {} }
+  ],
+  "connections": [
+    [ "esp:TX", "$serialMonitor:RX", "", [] ],
+    [ "esp:RX", "$serialMonitor:TX", "", [] ],
+    [ "rgb2:DIN", "esp:0", "green", [ "h28", "v-38.4" ] ],
+    [ "rgb2:DOUT", "rgb1:DIN", "green", [ "h-9.6", "v-10.5" ] ],
+    [ "rgb5:DOUT", "rgb7:DIN", "green", [ "h-9.6", "v-10.5" ] ],
+    [ "rgb8:DOUT", "rgb6:DIN", "green", [ "h-9.6", "v-10.5" ] ],
+    [ "rgb6:DOUT", "rgb4:DIN", "green", [ "v-0.9", "h-9.6", "v-9.6" ] ],
+    [ "rgb4:DOUT", "rgb3:DIN", "green", [ "v-0.9", "h-9.6", "v-9.6" ] ],
+    [ "rgb1:DOUT", "rgb5:DIN", "green", [ "h-9.6", "v-10.5" ] ],
+    [ "rgb2:VSS", "esp:5V", "red", [ "h18.4", "v75.9" ] ],
+    [ "rgb2:VDD", "rgb1:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb1:VDD", "rgb5:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb5:VDD", "rgb7:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb7:VDD", "rgb8:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb8:VDD", "rgb6:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb6:VDD", "rgb4:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb4:VDD", "rgb3:VSS", "red", [ "h-9.6", "v10.5" ] ],
+    [ "rgb3:VDD", "esp:GND.1", "black", [ "h-9.6", "v96" ] ],
+    [ "rgb8:DIN", "rgb7:DOUT", "green", [ "h8.8", "v9.6", "h9.6" ] ]
+  ],
+  "dependencies": {}
+}

--- a/esp32-led-strip-sdk/wokwi.toml
+++ b/esp32-led-strip-sdk/wokwi.toml
@@ -1,0 +1,8 @@
+# Wokwi Configuration File
+# Reference: https://docs.wokwi.com/vscode/project-config
+[wokwi]
+version = 1
+firmware = 'build/flasher_args.json'
+elf = 'build/main.elf'
+# gdbServerPort=3333
+


### PR DESCRIPTION
This PR adds files which are necessary for Wokwi simulation to run in the VS Code.
User needs to build the project, then the user can open diagra.json in VS Code with Wokwi plugin and just hit the Play button. This should will start the simulation.