### PR TITLE
Pico SDK 2.1.0 release - RISC-V Support docs update

### DIFF
--- a/pico-blink-sdk/README.md
+++ b/pico-blink-sdk/README.md
@@ -8,7 +8,7 @@ This example demonstrates how to integrate with the Pico SDK which is using CMak
 
 - A Raspberry Pi Pico (non-W) board. If you have a Pico W instead, refer to the [pico-w-blink-sdk](../pico-w-blink-sdk) sample instead.
 - Follow the setup steps at https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf, in particular you'll need:
-  - A checkout of the [pico-sdk](https://github.com/raspberrypi/pico-sdk.git), with git submodules checked out. If you'd like to try RISC-V support for RP2350, you'll need Pico SDK 2.0.1 or later (currently in the *development branch only*).
+  - A checkout of the [pico-sdk](https://github.com/raspberrypi/pico-sdk.git), with git submodules checked out. If you'd like to try RISC-V support for RP2350, you'll need Pico SDK 2.1.0 or later.
   - A checkout of the [pico-examples](https://github.com/raspberrypi/pico-examples.git).
   - CMake.
   - The [Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads), or the RISC-V tollchain if you want to build for the RISC-V cores on the RP2350.

--- a/pico-blink-sdk/README.md
+++ b/pico-blink-sdk/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to integrate with the Pico SDK which is using CMak
   - A checkout of the [pico-sdk](https://github.com/raspberrypi/pico-sdk.git), with git submodules checked out. If you'd like to try RISC-V support for RP2350, you'll need Pico SDK 2.1.0 or later.
   - A checkout of the [pico-examples](https://github.com/raspberrypi/pico-examples.git).
   - CMake.
-  - The [Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads), or the RISC-V tollchain if you want to build for the RISC-V cores on the RP2350.
+  - The [Arm Embedded Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads), or the RISC-V toolchain if you want to build for the RISC-V cores on the RP2350.
 - Before trying to use Swift with the Pico SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
   - Try building and running the "blink" example from pico-examples written in C.
 


### PR DESCRIPTION
This PR is a small docs update.

Raspberry Pi had released the [Pico SDK version 2.1.0](https://github.com/raspberrypi/pico-sdk/releases/tag/2.1.0), which now includes the patch required to compile the Pico SDK examples for the RISC-V cores on the RP2350 (so users don't need to download the development branch anymore).