### PR TITLE
Fix error in displaySize

### DIFF
--- a/stm32-lcd-logo/Support/Board.swift
+++ b/stm32-lcd-logo/Support/Board.swift
@@ -53,8 +53,8 @@ struct STM32F746Board {
 
   var displaySize: Size {
     Size(
-      width: STM32F746.LTDCConstants.DISPLAY_WIDTH,
-      height: STM32F746.LTDCConstants.DISPLAY_HEIGHT)
+      width: STM32F746.LTDCConstants.displayWidth,
+      height: STM32F746.LTDCConstants.displayHeight)
   }
 
   var logoLayerSize: Size {


### PR DESCRIPTION
`HAL.swift` and `Board.swift` had different names for display width  and display height.
This change renames vars in Board.swift to have the same names as in `HAL.swift`