### PR TITLE
Fix build of pico2-neopixel (missing rename of pioInstructions)

### DIFF
--- a/pico2-neopixel/Sources/Application/Application.swift
+++ b/pico2-neopixel/Sources/Application/Application.swift
@@ -48,7 +48,7 @@ func configureOutputPin() {
 /// `clkdiv_restart` to clear any persisted state.
 func configurePio() {
   // Load the assembled program directly into the PIO's instruction memory.
-  withUnsafeBytes(of: WS2812.pio_instructions) { pointer in
+  withUnsafeBytes(of: WS2812.pioInstructions) { pointer in
     let pioInstructions = pointer.assumingMemoryBound(to: UInt16.self)
     for (index, pio_instr) in pioInstructions.enumerated() {
       pio0.instr_mem[index].write { w in


### PR DESCRIPTION
Fixes a build error:
```
/Users/kuba/Documents/swift-embedded-examples/pico2-neopixel/Sources/Application/Application.swift:51:30: error: type 'WS2812' has no member 'pio_instructions'
 49 | func configurePio() {
 50 |   // Load the assembled program directly into the PIO's instruction memory.
 51 |   withUnsafeBytes(of: WS2812.pio_instructions) { pointer in
    |                              `- error: type 'WS2812' has no member 'pio_instructions'
 52 |     let pioInstructions = pointer.assumingMemoryBound(to: UInt16.self)
 53 |     for (index, pio_instr) in pioInstructions.enumerated() {

make: *** [build] Error 1
```