### PR TITLE
Use uv to manage python deps

### DIFF
--- a/.github/workflows/build-stm.yml
+++ b/.github/workflows/build-stm.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
       - name: Install ${{ matrix.swift }}
         run: |
           wget -q https://download.swift.org/development/ubuntu2404/${{ matrix.swift }}/${{ matrix.swift }}-ubuntu24.04.tar.gz
@@ -39,6 +42,5 @@ jobs:
       - name: Build ${{ matrix.example }}
         working-directory: ${{ matrix.example }}
         run: |
-          pip3 install -r ../Tools/requirements.txt
           export STM_BOARD=STM32F746G_DISCOVERY
           ./build-elf.sh

--- a/README.md
+++ b/README.md
@@ -19,14 +19,9 @@ Each example in this repository contains build and deployment instructions, howe
 	
   You can follow the [tutorial here](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/setup-macos/) for instructions on installing and using nighly Swift toolchains.
 
-2. Install the Python3 dependencies listed in `requirements.txt`.
+2. Install [`uv`](https://github.com/astral-sh/uv) "an extremely fast Python package and project manager".
 
-  ```console
-  $ cd swift-embedded-examples
-  $ python3 -m venv .venv
-  $ source .venv/bin/activate
-  $ python3 -m pip install -r Tools/requirements.txt
-  ```
+  You can follow the [instructions here](https://docs.astral.sh/uv/getting-started/installation/) to install `uv`.
 
 ## Catalog of Examples
 

--- a/Tools/elf2hex.py
+++ b/Tools/elf2hex.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env -S python3 -u -tt
+#! /usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "pyelftools==0.31",
+# ]
+# ///
 
 # This source file is part of the Swift open source project
 #

--- a/Tools/macho2bin.py
+++ b/Tools/macho2bin.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3 -u -tt
+#! /usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "macholib==1.16.3",
+# ]
+# ///
 
 # This source file is part of the Swift open source project
 #

--- a/Tools/macho2uf2.py
+++ b/Tools/macho2uf2.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3 -u -tt
+#! /usr/bin/env -S uv run --script
+
+# /// script
+# dependencies = [
+#   "macholib==1.16.3",
+# ]
+# ///
 
 # This source file is part of the Swift open source project
 #

--- a/Tools/requirements.txt
+++ b/Tools/requirements.txt
@@ -1,2 +1,0 @@
-macholib==1.16.3
-pyelftools==0.31


### PR DESCRIPTION
Instead of having users manually manage python venvs this commit migrates the python scripts to use `uv` which can handle installing script dependencies automatically. Additionally it doesn't require sourcing a venv setup script in every shell where you want to build.

A further improvement on the swift swift side should also be made to use swiftly to manage swift toolchain versions instead of the `TOOLCHAINS` env variable.