### PR TITLE
Change base address and entry point

### DIFF
--- a/Tools/Toolsets/stm32f74x.json
+++ b/Tools/Toolsets/stm32f74x.json
@@ -13,11 +13,11 @@
       "-arch", "armv7em",
       "-dead_strip",
       "-static",
-      "-e", "_reset",
+      "-e", "_vector_table",
       "-no_zero_fill_sections",
       "-segalign", "4",
-      "-segaddr", "__VECTORS", "0x20010000",
-      "-seg1addr", "0x20010200",
+      "-segaddr", "__VECTORS", "0x08000000",
+      "-seg1addr", "0x08000200",
       "-pagezero_size", "0",
       "-allow_dead_duplicates"
     ]

--- a/stm32-lcd-logo/Makefile
+++ b/stm32-lcd-logo/Makefile
@@ -46,7 +46,7 @@ build:
 
 	@echo "extracting binary..."
 	$(MACHO2BIN) \
-		$(BUILDROOT)/Application $(BUILDROOT)/Application.bin --base-address 0x20010000 --segments '__TEXT,__DATA,__VECTORS'
+		$(BUILDROOT)/Application $(BUILDROOT)/Application.bin --base-address 0x08000000 --segments '__TEXT,__DATA,__VECTORS'
 
 .PHONY: clean
 clean:

--- a/stm32-lcd-logo/Sources/Support/Startup.c
+++ b/stm32-lcd-logo/Sources/Support/Startup.c
@@ -16,6 +16,7 @@ extern int main(int argc, char *argv[]);
 
 void reset(void) {
     main(0, NULL);
+    while (1) {}
 }
 
 void interrupt(void) {
@@ -24,7 +25,7 @@ void interrupt(void) {
 
 __attribute((used)) __attribute((section("__VECTORS,__text")))
 void *vector_table[114] = {
-    (void *)0x2000fffc, // initial SP
+    (void *)0x20050000, // initial SP
     reset, // Reset
 
     interrupt, // NMI


### PR DESCRIPTION
The only thing that works in the stm32-lcd-logo is the LED blink, and only if all other code that requires memory allocation is removed from Application.swift