### PR TITLE
Reduce references to TOOLCHAINS

### DIFF
--- a/Sources/EmbeddedSwift/Documentation.docc/SDKSupport/IntegrateWithPico.md
+++ b/Sources/EmbeddedSwift/Documentation.docc/SDKSupport/IntegrateWithPico.md
@@ -95,7 +95,6 @@ pico_add_extra_outputs(swift-blinky)
 With these three files, we can now configure and build a Swift firmware for the Pico:
 
 ```bash
-$ export TOOLCHAINS=org.swift.59202401301a
 $ export PICO_BOARD=pico
 $ export PICO_SDK_PATH=<path_to_pico_sdk>
 $ export PICO_TOOLCHAIN_PATH=<path_to_arm_toolchain>

--- a/esp32-led-blink-sdk/README.md
+++ b/esp32-led-blink-sdk/README.md
@@ -17,10 +17,9 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - If needed, run export.sh to get access to the idf.py script from ESP-IDF.
-- Specify the nightly toolchain to be used via the `TOOLCHAINS` environment variable and the target board type by using `idf.py set-target`.
+- Specify the target board type by using `idf.py set-target`.
 ``` console
 $ cd esp32-led-blink-sdk
-$ export TOOLCHAINS=...
 $ . <path-to-esp-idf>/export.sh
 $ idf.py set-target esp32c6
 $ idf.py build

--- a/esp32-led-strip-sdk/README.md
+++ b/esp32-led-strip-sdk/README.md
@@ -16,10 +16,9 @@ This example demonstrates how to integrate with the ESP-IDF SDK via CMake and ho
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - If needed, run export.sh to get access to the idf.py script from ESP-IDF.
-- Specify the nightly toolchain to be used via the `TOOLCHAINS` environment variable and the target board type by using `idf.py set-target`.
+- Specify and the target board type by using `idf.py set-target`.
 ``` console
 $ cd esp32-led-strip-sdk
-$ export TOOLCHAINS=...
 $ . <path-to-esp-idf>/export.sh
 $ idf.py set-target esp32c6
 $ idf.py build

--- a/harmony/README.md
+++ b/harmony/README.md
@@ -51,7 +51,6 @@ The firmware for Harmony is built using CMake and requires the Raspberry Pi Pico
 
 3.  Set the necessary environment variables:
     ```bash
-    export TOOLCHAINS='<toolchain-identifier>' # e.g., gcc-arm-none-eabi
     export PICO_BOARD=pico_w
     export PICO_SDK_PATH='<path-to-your-pico-sdk>' # e.g., ../pico-sdk
     export PICO_EXTRAS_PATH='<path-to-your-pico-extras>' # e.g., ../pico-extras

--- a/nrfx-blink-sdk/README.md
+++ b/nrfx-blink-sdk/README.md
@@ -19,11 +19,10 @@ This example demonstrates how to integrate with the Zephyr SDK via CMake and how
 ## Building
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
-- Build the program in the Zephyr virtualenv, specify the nightly toolchain to be used via the `TOOLCHAINS` environment variable and the target board type via the `-DBOARD=...` CMake setting:
+- Build the program in the Zephyr virtualenv, specify the target board type via the `-DBOARD=...` CMake setting:
 ``` console
 $ cd nrfx-blink-sdk
 $ source ~/zephyrproject/.venv/bin/activate
-(.venv) export TOOLCHAINS='<toolchain-identifier>'
 (.venv) cmake -B build -G Ninja -DBOARD=nrf52840dk_nrf52840 -DUSE_CCACHE=0 .
 (.venv) cmake --build build
 ```

--- a/rpi-pico-blink-sdk/README.md
+++ b/rpi-pico-blink-sdk/README.md
@@ -23,7 +23,6 @@ This example demonstrates how to integrate with the Pico SDK which is using CMak
 
 ``` console
 $ cd rpi-pico-blink-sdk
-$ export TOOLCHAINS='<toolchain-identifier>'
 $ export PICO_BOARD='<board-name>' # Examples: pico, pico2
 $ export PICO_PLATFORM='<optional-platform-name>' # Optional; useful if you'd like to compile for RISC-V. Examples: rp2040, rp2350-arm-s, rp2350-riscv 
 $ export PICO_SDK_PATH='<path-to-your-pico-sdk>'

--- a/rpi-pico2-neopixel/README.md
+++ b/rpi-pico2-neopixel/README.md
@@ -37,7 +37,7 @@ index f6867b5..a2291db 100644
 - Build and copy the program in the UF2 format to the Mass Storage device to trigger flashing the program into memory (after which the device will reboot and run the firmware):
 ``` console
 $ cd rpi-pico2-neopixel
-$ TOOLCHAINS='<toolchain-identifier>' make
+$ make
 $ cp .build/release/Application.uf2 /Volumes/RP2350
 ```
 - The RGB LED should be animating through the color wheel.

--- a/rpi-picow-blink-sdk/README.md
+++ b/rpi-picow-blink-sdk/README.md
@@ -22,7 +22,6 @@ This example demonstrates how to integrate with the Pico SDK which is using CMak
 - Build and copy the program in the UF2 format to the Mass Storage device to trigger flashing the program into memory (after which the device will reboot and run the firmware):
 ``` console
 $ cd rpi-picow-blink-sdk
-$ export TOOLCHAINS='<toolchain-identifier>'
 $ export PICO_BOARD=pico_w
 $ export PICO_SDK_PATH='<path-to-your-pico-sdk>'
 $ export PICO_TOOLCHAIN_PATH='<path-to-the-arm-toolchain>'

--- a/stm32-blink/README.md
+++ b/stm32-blink/README.md
@@ -15,7 +15,6 @@ This example shows a simple baremetal firmware for an STM32 board that blinks an
 - Build and upload the program to flash memory of the microcontroller:
 ```console
 $ cd stm32-blink
-$ export TOOLCHAINS=$(plutil -extract CFBundleIdentifier raw /Library/Developer/Toolchains/swift-latest.xctoolchain/Info.plist)
 $ export STM_BOARD=STM32F746G_DISCOVERY   # or NUCLEO_F103RB
 $ ./build-macho.sh
 $ st-flash --reset write .build/blink.bin 0x08000000
@@ -27,10 +26,6 @@ $ st-flash --reset write .build/blink.bin 0x08000000
 - Build and upload the program to flash memory of the microcontroller:
 ```console
 $ cd stm32-blink
-
-# If on macOS, select the right latest nightly toolchain (on Linux this is not needed):
-$ export TOOLCHAINS=$(plutil -extract CFBundleIdentifier raw /Library/Developer/Toolchains/swift-latest.xctoolchain/Info.plist)
-
 $ export STM_BOARD=STM32F746G_DISCOVERY   # or NUCLEO_F103RB
 $ ./build-elf.sh
 $ st-flash --format ihex --reset write .build/blink.hex

--- a/stm32-lcd-logo/README.md
+++ b/stm32-lcd-logo/README.md
@@ -10,7 +10,7 @@
 - Build and upload the program to flash memory of the STM:
 ```console
 $ cd stm32-lcd-logo
-$ TOOLCHAINS='<toolchain-identifier>' ./build.sh
+$ make
 $ st-flash --reset write .build/lcd-logo.bin 0x08000000
 ```
 - The LCD display on the board should now be showing a bouncing animating Swift logo on a fading background, and the user LED on should be blinking.

--- a/stm32-neopixel/README.md
+++ b/stm32-neopixel/README.md
@@ -24,7 +24,6 @@ We recommend including a capacitor across the LED strip power supply.
 - Build and upload the program to flash memory of the STM:
 ```console
 $ cd stm32-neopixel
-$ export TOOLCHAINS='<toolchain-identifier>'
 $ make
 $ st-flash --reset write .build/release/Application.bin 0x08000000
 ```

--- a/stm32-uart-echo/README.md
+++ b/stm32-uart-echo/README.md
@@ -14,7 +14,6 @@ $ screen /dev/cu.usbmodem<...> 115200
 - Build and upload the program to flash memory of the STM:
 ```console
 $ cd stm32-uart-echo
-$ export TOOLCHAINS='<toolchain-identifier>'
 $ make
 $ st-flash --reset write .build/release/Application.bin 0x08000000
 ```


### PR DESCRIPTION
In preparation for new install swift documention recommending swiftly, this commit removes many references to the TOOLCHAINS env var used by xcrun which is no longer recommended.