### PR TITLE
Write install swift documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,13 @@ This repository is a set of demonstration projects of **Embedded Swift**. Embedd
 - [Embedded Swift Vision Document](https://github.com/apple/swift-evolution/blob/main/visions/embedded-swift.md)
 - [Documentation for Embedded Swift](https://github.com/apple/swift/tree/main/docs/EmbeddedSwift)
 
-> [!WARNING]
-> Embedded Swift is experimental. Some information on this page might be out of date with latest development.
-
 ## Building the examples
 
 Each example in this repository contains build and deployment instructions, however there are a couple common steps needed for many of the examples included below:
 
-1. Install the latest downloadable 'main' [Development Snapshot](https://www.swift.org/install/macos/#development-snapshots) from swift.org to use Embedded Swift. Public releases of Swift do not yet support Embedded Swift.
-	
-  You can follow the [tutorial here](https://apple.github.io/swift-matter-examples/tutorials/swiftmatterexamples/setup-macos/) for instructions on installing and using nighly Swift toolchains.
+1. Install [`swift`](https://swift.org) using the [instructions here](https://swiftpackageindex.com/apple/swift-embedded-examples/main/documentation/embeddedswift/installembeddedswift).
 
-2. Install [`uv`](https://github.com/astral-sh/uv) "an extremely fast Python package and project manager".
-
-  You can follow the [instructions here](https://docs.astral.sh/uv/getting-started/installation/) to install `uv`.
+2. Install [`uv`](https://github.com/astral-sh/uv), "an extremely fast Python package and project manager", using the [instructions here](https://docs.astral.sh/uv/getting-started/installation/).
 
 ## Catalog of Examples
 

--- a/Sources/EmbeddedSwift/Documentation.docc/Documentation.md
+++ b/Sources/EmbeddedSwift/Documentation.docc/Documentation.md
@@ -1,6 +1,8 @@
 # ``EmbeddedSwift``
 
-<!--@START_MENU_TOKEN@-->Summary<!--@END_MENU_TOKEN@-->
+@Metadata {
+  @DisplayName("Embedded Swift")
+}
 
 ## Overview
 

--- a/Sources/EmbeddedSwift/Documentation.docc/GettingStarted/InstallEmbeddedSwift.md
+++ b/Sources/EmbeddedSwift/Documentation.docc/GettingStarted/InstallEmbeddedSwift.md
@@ -1,3 +1,30 @@
 # Install Embedded Swift
 
-🚧 Under construction...
+Get the tools needed to use Embedded Swift.
+
+## Overview
+
+Embedded Swift is an experimental and rapidly developing feature of the Swift language, as such it is only available in "Development Snapshot". 
+
+The best way to install Swift is using [`swiftly`](http://github.com/swiftlang/swiftly), the official Swift toolchain installer and manager. For instructions on how to install `swiftly`, check out the [Getting Started](https://www.swift.org/swiftly/documentation/swiftly/getting-started) guide.
+
+> Note: Swiftly installs the latest release toolchain during `swiftly init`, if you only plan on using Embedded Swift, you can avoid downloading this toolchain by using the `swiftly init --skip-install` option. 
+
+After installing Swiftly, install the latest main "Development Snapshot" toolchain available for your platform by running:
+
+```shell
+$ swiftly install main-snapshot
+...
+main-snapshot-2025-04-12 installed successfully!
+```
+
+To test that you have Swift installed, run `swift --version` from your shell or terminal app. It should say "6.2-dev", meaning you have a "Development Snapshot" toolchain.
+
+```shell
+$ swift --version
+Apple Swift version 6.2-dev (LLVM 81ab6d9f7e4810f, Swift 9cc1947527bacea)
+Target: arm64-apple-macosx15.0
+Build config: +assertions
+```
+
+> Warning: When using other shells, like one integrated into an IDE, be careful to verify that the version of Swift reported matches that of the shell you used to install Swift.


### PR DESCRIPTION
Adds an initial document on how to install a toolchain that supports Embedded Swift.