### PR TITLE
Improve nrfx-blink-sdk example to automatically get Zephyr defines and show using nrfutil instead of nrfjprog

### DIFF
--- a/nrfx-blink-sdk/CMakeLists.txt
+++ b/nrfx-blink-sdk/CMakeLists.txt
@@ -28,12 +28,23 @@ add_compile_options(
     # Disable PIC
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -fno-pic>"
 
-    # Assortment of defines for Zephyr
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DKERNEL -Xcc -DNRF52840_XXAA -Xcc -DPICOLIBC_INTEGER_PRINTF_SCANF -Xcc -D_FORTIFY_SOURCE=1 -Xcc -D_POSIX_C_SOURCE=200809 -Xcc -D__LINUX_ERRNO_EXTENSIONS__ -Xcc -D__PROGRAM_START -Xcc -D__ZEPHYR__=1>"
-
     # Add Libc include paths
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I -Xcc ${ZEPHYR_SDK_INSTALL_DIR}/arm-zephyr-eabi/picolibc/include>"
 )
+
+# Add definitions from Zephyr to -Xcc flags
+get_target_property(ZEPHYR_DEFINES zephyr_interface INTERFACE_COMPILE_DEFINITIONS)
+if(ZEPHYR_DEFINES)
+    foreach(flag ${ZEPHYR_DEFINES})
+        # Ignore expressions like "$<SOMETHING>"
+        string(FIND "${flag}" "$<" start_of_expression)
+        if(NOT start_of_expression EQUAL -1)
+            continue()
+        endif()
+
+        add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -D${flag}>")
+    endforeach()
+endif()
 
 target_sources(app PRIVATE Stubs.c)
 

--- a/nrfx-blink-sdk/README.md
+++ b/nrfx-blink-sdk/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to integrate with the Zephyr SDK via CMake and how
   - The West build system.
   - A Python virtualenv for Zephyr.
   - Zephyr SDK/toolchain.
-  - Host flash/debug tools for the board you're using. For example, for the nRF52840-DK board you'll need the [nRF Command Line Tools](https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools).
+  - Host flash/debug tools for the board you're using. For example, for the nRF52840-DK board you'll need the [nRF Util](https://www.nordicsemi.com/Products/Development-tools/nRF-Util).
 
 - Before trying to use Swift with the Zephyr SDK, make sure your environment works and can build the provided C/C++ sample projects, in particular:
   - Try building and running the "simple/blink" example from Zephyr written in C.
@@ -20,7 +20,8 @@ This example demonstrates how to integrate with the Zephyr SDK via CMake and how
 
 - Make sure you have a recent nightly Swift toolchain that has Embedded Swift support.
 - Build the program in the Zephyr virtualenv, specify the target board type via the `-DBOARD=...` CMake setting:
-``` console
+
+```console
 $ cd nrfx-blink-sdk
 $ source ~/zephyrproject/.venv/bin/activate
 (.venv) cmake -B build -G Ninja -DBOARD=nrf52840dk/nrf52840 -DUSE_CCACHE=0 .
@@ -30,11 +31,12 @@ $ source ~/zephyrproject/.venv/bin/activate
 ## Running
 
 - Connect the nRF52840-DK board over a USB cable to your Mac using the J-Link connector on the board.
-- Use `nrfjprog` to upload the firmware and to run it:
+- Use the `nrfutil device` command to upload the firmware and to run it:
 
 ```console
-(.venv) nrfjprog --recover --program build/zephyr/zephyr.hex --verify
-(.venv) nrfjprog --run
+(.venv) nrfutil device program --firmware build/zephyr/zephyr.hex
+(.venv) nrfutil device fw-verify --firmware build/zephyr/zephyr.hex
+(.venv) nrfutil device reset
 ```
 
 - The green LED should now be blinking in a pattern.


### PR DESCRIPTION
@kubamracek I figured out how to get the Zephyr defines programmatically in CMakeLists.txt so that they don't have to be hardcoded. Please have a look!

1. Instead of manually setting the compiler defines that Zephyr provides (`-D__ZEPHYR__=1`, `-DKERNEL`, etc), we dynamically grab them from the `zephyr_interface INTERFACE_COMPILE_DEFINITIONS` and set -Xcc flags for Swift compilation instead.
2. The [nRF Command Line Tools are deprecated](https://www.nordicsemi.com/Products/Development-tools/nRF-Command-Line-Tools) and have been replaced by the nRF Util tool instead. As such, I've updated the README.md to show using `nrfutil` instead of `nrfjprog`.

@rauhul I have also been working on an `Integration with Zephyr` document for this repo, but still in progress. I'm hoping to have something soon in the next few weeks that we can look at.