### PR TITLE
Pin Zephyr SDK version

### DIFF
--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           app-path: ${{ matrix.example }}
           toolchains: arm-zephyr-eabi
+          sdk-version: 0.17.0
 
       - name: Install Swift
         uses: ./.github/actions/install-swift

--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -3,8 +3,6 @@ name: Zephyr
 on:
   push:
     branches: ["main"]
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   build:

--- a/nrfx-blink-sdk/west.yml
+++ b/nrfx-blink-sdk/west.yml
@@ -9,5 +9,5 @@ manifest:
       revision: main
       import:
         name-allowlist:
-          - cmsis  # required by the ARM port
+          - cmsis_6  # required by the ARM port
           - hal_nordic  # required by the custom_plank board (Nordic based)

--- a/nrfx-blink-sdk/west.yml
+++ b/nrfx-blink-sdk/west.yml
@@ -9,5 +9,5 @@ manifest:
       revision: main
       import:
         name-allowlist:
-          - cmsis_6  # required by the ARM port
+          - cmsis  # required by the ARM port
           - hal_nordic  # required by the custom_plank board (Nordic based)


### PR DESCRIPTION
CI builds using the Zephyr SDK due to an update incompatible with our example app. Before resolving the issue with newer SDKs this PR pins the version of Zephyr used in CI.