### PR TITLE
Lock Zephyr version to v4.1.0 for nrx-blink-sdk example

### DIFF
--- a/.github/workflows/build-zephyr.yml
+++ b/.github/workflows/build-zephyr.yml
@@ -3,6 +3,8 @@ name: Zephyr
 on:
   push:
     branches: ["main"]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 jobs:

--- a/nrfx-blink-sdk/README.md
+++ b/nrfx-blink-sdk/README.md
@@ -23,7 +23,7 @@ This example demonstrates how to integrate with the Zephyr SDK via CMake and how
 ``` console
 $ cd nrfx-blink-sdk
 $ source ~/zephyrproject/.venv/bin/activate
-(.venv) cmake -B build -G Ninja -DBOARD=nrf52840dk_nrf52840 -DUSE_CCACHE=0 .
+(.venv) cmake -B build -G Ninja -DBOARD=nrf52840dk/nrf52840 -DUSE_CCACHE=0 .
 (.venv) cmake --build build
 ```
 

--- a/nrfx-blink-sdk/west.yml
+++ b/nrfx-blink-sdk/west.yml
@@ -6,7 +6,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: v4.1.0
       import:
         name-allowlist:
           - cmsis  # required by the ARM port


### PR DESCRIPTION
Using the `main` revision of Zephyr can have unintended side-effects and changes, so it's best to use a stable/tagged version instead.

Also updated the README.md to include the correct `-DBOARD=nrf52840dk/nrf52840` definition for the cmake command, since the previous `-DBOARD=nrf52840dk_nrf52840` is now invalid in the latest version of Zephyr.

@rauhul 
