### PR TITLE
Update spi yml for new docs path

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,5 +1,3 @@
 version: 1
-builder:
-  configs:
-    - documentation_targets:
-        - EmbeddedSwift
+external_links:
+  documentation: "https://docs.swift.org/embedded/documentation/embedded"


### PR DESCRIPTION
Embedded swift documentation is now hosted on swift.org. This commit updates the spi.yml file to point at the new host so swift package index will link to the correct site.